### PR TITLE
Add project docs and planning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent Instructions
+
+These notes guide Codex contributors working on the Shape CLI project.
+
+## Repository Overview
+
+- **Runtime**: Bun (not Node).
+- **Language**: TypeScript only.
+- **Formatting/Linting**: Use Biome and Ultracite. Do not use ESLint or Prettier.
+- **Testing**: Use Vitest for unit and integration tests.
+- **Package Manager**: `bun` should manage dependencies.
+
+## Development Tips
+
+- Always read `PRD.md` for functional requirements before implementing features.
+- Keep all source under `src/` and tests under `tests/`.
+- Ensure `bun.lockb` stays committed for reproducible installs.
+- The project should be able to run with `bun src/index.ts` once implemented.
+
+## Workflow
+
+1. Create or update tasks in `TODO.md` before coding.
+2. Run `bun test` to execute the Vitest suite.
+3. Use `bunx biome` and `bunx ultracite` for formatting and linting.
+4. Keep the repository clean with `git status` before each commit.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Shape CLI
+
+Shape is a command‑line tool that generates a solid colour PNG rectangle.
+
+## Features
+
+- Written in **TypeScript** using **Bun** runtime.
+- Provides a simple CLI to specify width, height, and colour.
+- Outputs a PNG file named `rectangle_<w>x<h>.png` by default.
+- Validates inputs and supports colour normalisation heuristics.
+- Includes tests written with **Vitest**.
+- Formatting and linting handled by **Biome** and **Ultracite**.
+
+## Usage
+
+```bash
+bunx @iamkaf/shape WIDTH HEIGHT COLOR [--output <file>] [--force] [--verbose] [--strict-color]
+```
+
+See `shape --help` for command details.
+
+## Development
+
+This project uses Bun and TypeScript. Install dependencies with:
+
+```bash
+bun install
+```
+
+Run tests with:
+
+```bash
+bun test
+```
+
+Formatting and linting are handled by Biome and Ultracite:
+
+```bash
+bun run format
+bun run lint
+```
+
+## Project Goals
+
+See [PRD.md](PRD.md) for the full product requirements.
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,49 @@
+# Development Plan
+
+This file tracks the high level phases for building Shape CLI. Each phase delivers a usable increment.
+
+## Phase 1 – Setup
+- Initialize repository with Bun and TypeScript.
+- Configure Biome and Ultracite.
+- Add Vitest for testing.
+- Establish directory structure (`src/`, `tests/`).
+
+## Phase 2 – Tracer Bullet
+- Implement a minimal end-to-end CLI that accepts width, height, and colour.
+- Hardcode PNG generation with a single colour as placeholder.
+- Provide basic argument parsing and file output.
+
+## Phase 3 – Input Validation
+- Enforce dimension limits and positive integers.
+- Implement colour normalisation heuristics.
+- Support `--strict-color` mode.
+
+## Phase 4 – PNG Generation
+- Replace placeholder with real image creation using `sharp` (primary) and `pngjs` fallback.
+- Ensure atomic file writing.
+
+## Phase 5 – CLI Flags and Error Handling
+- Add `--output`, `--force`, `--verbose`, and `--help` flags.
+- Implement exit codes per PRD.
+
+## Phase 6 – Testing Suite
+- Add unit tests for colour normalisation and validation.
+- Add golden tests for PNG output.
+- Add CLI smoke tests.
+
+## Phase 7 – Documentation
+- Update README with detailed usage and examples.
+- Document development workflow and contribution guide.
+
+## Phase 8 – Optimisations
+- Improve performance for large images.
+- Review memory usage and refine implementation.
+
+## Phase 9 – Packaging
+- Prepare for distribution on npm under `@iamkaf/shape`.
+- Create CLIs for `bunx` usage and bundling steps.
+
+## Phase 10 – Cleanup and Publishing
+- Final code cleanup and dependency audit.
+- Tag release, publish package, and announce project.
+


### PR DESCRIPTION
## Summary
- create initial README for Shape CLI project using Bun and TypeScript
- add AGENTS.md with repo guidance
- add TODO.md outlining 10-phase development plan

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877d77643d48331885104c07aa46387