### PR TITLE
Add failing test suite for phase 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "start": "bun src/index.ts",
     "format": "biome format --write ./src",
     "lint": "ultracite lint ./src",
-    "check": "biome check ./src"
+    "check": "biome check ./src",
+    "test": "bun test",
+    "test:coverage": "bun test --coverage"
   },
   "dependencies": {
     "commander": "^14.0.0",

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -1,0 +1,4 @@
+// TODO: implement colour normalisation heuristics
+export function normalizeColor(input: string, strict = false): string {
+  return input;
+}

--- a/src/lib/dimensions.ts
+++ b/src/lib/dimensions.ts
@@ -1,0 +1,4 @@
+// TODO: implement dimension parsing and validation
+export function parseDimensions(widthStr: string, heightStr: string): { width: number; height: number } {
+  return { width: Number.parseInt(widthStr, 10), height: Number.parseInt(heightStr, 10) };
+}

--- a/tests/cli/smoke.test.ts
+++ b/tests/cli/smoke.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'bun:test';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+
+const cli = join(import.meta.dir, '../../src/index.ts');
+
+describe('cli smoke tests', () => {
+  it('creates a file with the default name', () => {
+    if (existsSync('rectangle_3x3.png')) rmSync('rectangle_3x3.png');
+    const result = spawnSync('bun', [cli, '3', '3', 'red']);
+    expect(result.status).toBe(0);
+    expect(existsSync('rectangle_3x3.png')).toBe(true);
+  });
+
+  it('fails for negative width', () => {
+    const result = spawnSync('bun', [cli, '-1', '3', 'red']);
+    expect(result.status).toBe(64);
+  });
+});

--- a/tests/integration/golden.test.ts
+++ b/tests/integration/golden.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'bun:test';
+import { join } from 'node:path';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
+import { generate } from '../../src/index';
+
+describe('PNG generation', () => {
+  it('matches golden hash for 3x3 red PNG', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'shape-'));
+    const file = join(dir, 'out.png');
+    await generate(3, 3, 'red', file);
+    const data = readFileSync(file);
+    const hash = createHash('sha256').update(data).digest('hex');
+    expect(hash).toBe('9e0d5b9fdaa3d1d4256dd0c1eebcd7f28c46bd4b9dc59fc95d5fd0f2dedf74c9');
+  });
+});

--- a/tests/unit/color.test.ts
+++ b/tests/unit/color.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test';
+import { normalizeColor } from '../../src/lib/color';
+
+describe('color normalisation', () => {
+  it('normalises named colours', () => {
+    expect(normalizeColor(' red ')).toBe('#ff0000');
+  });
+
+  it('recovers mistyped colours', () => {
+    expect(normalizeColor('bleu')).toBe('#0000ff');
+  });
+
+  it('throws in strict mode for invalid colour', () => {
+    expect(() => normalizeColor('blu', true)).toThrow();
+  });
+});

--- a/tests/unit/dimensions.test.ts
+++ b/tests/unit/dimensions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { parseDimensions } from '../../src/lib/dimensions';
+
+describe('parseDimensions', () => {
+  it('parses valid dimensions', () => {
+    expect(parseDimensions('10', '20')).toEqual({ width: 10, height: 20 });
+  });
+
+  it('rejects zero width', () => {
+    expect(() => parseDimensions('0', '10')).toThrow();
+  });
+
+  it('rejects negative height', () => {
+    expect(() => parseDimensions('10', '-1')).toThrow();
+  });
+
+  it('rejects width larger than int32', () => {
+    expect(() => parseDimensions('3000000000', '1')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- stub out color and dimension helpers
- add placeholder unit tests for color and dimension logic
- add PNG golden test
- add CLI smoke tests checking default output name
- wire up test and coverage scripts

## Testing
- `bun test --coverage` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_6877eb051b4c8331b8954abe2b189ab3